### PR TITLE
Make main the stable branch authority

### DIFF
--- a/.github/ISSUE_TEMPLATE/cross_repository.yml
+++ b/.github/ISSUE_TEMPLATE/cross_repository.yml
@@ -43,8 +43,8 @@ body:
       options:
         - durable-workflow/.github@main
         - durable-workflow/ai@main
-        - durable-workflow/workflow@v2
-        - durable-workflow/waterline@v2
+        - durable-workflow/workflow@main
+        - durable-workflow/waterline@main
         - durable-workflow/server@main
         - durable-workflow/cli@main
         - durable-workflow/sdk-php@main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,9 +155,8 @@ not post lease heartbeats, raw local logs, or vague status text.
 
 - Never move or reuse a published tag. Release new versions according to
   semantic versioning.
-- Workflow and Waterline develop on `v2`; `master` is only for explicitly
-  approved 1.x maintenance until their tracked branch migrations make `main`
-  the stable 2.x branch and `1.x` the maintenance branch.
+- Workflow and Waterline develop on `main`; `1.x` is only for explicitly
+  approved maintenance of the legacy 1.x line.
 - Server, CLI, AI, PHP SDK, Python SDK, and Rust SDK develop on `main`.
 - Each package repository owns ordinary semantic-version releases and
   publication through a small repository-local workflow. Sample App, Cloud,

--- a/qualification/policy.json
+++ b/qualification/policy.json
@@ -251,7 +251,7 @@
       ]
     },
     "waterline": {
-      "branch": "v2",
+      "branch": "main",
       "repository": "waterline",
       "workflows": [
         {
@@ -263,7 +263,7 @@
       ]
     },
     "workflow": {
-      "branch": "v2",
+      "branch": "main",
       "repository": "workflow",
       "workflows": [
         {

--- a/qualification/schema.json
+++ b/qualification/schema.json
@@ -95,10 +95,7 @@
       "additionalProperties": false,
       "properties": {
         "branch": {
-          "enum": [
-            "main",
-            "v2"
-          ]
+          "const": "main"
         },
         "repository": {
           "minLength": 1,

--- a/scripts/qualification_policy.py
+++ b/scripts/qualification_policy.py
@@ -37,8 +37,8 @@ EXPECTED_TARGETS = {
     "sdk-python": ("sdk-python", "main"),
     "sdk-rust": ("sdk-rust", "main"),
     "server": ("server", "main"),
-    "waterline": ("waterline", "v2"),
-    "workflow": ("workflow", "v2"),
+    "waterline": ("waterline", "main"),
+    "workflow": ("workflow", "main"),
 }
 EXPECTED_PUBLIC_AUDIT_TARGETS = set(EXPECTED_TARGETS) - {"cloud"}
 GITHUB_API_MAX_ATTEMPTS = 5


### PR DESCRIPTION
Updates the public agent guide, issue template, and qualification policy so Workflow and Waterline use `main` for current stable development and `1.x` for legacy maintenance.

This aligns the organization-wide coordination contract with the completed branch renames.